### PR TITLE
Fix example Collection Object URLs

### DIFF
--- a/docs/v1-1/OpenDirect_OOH_1-5-1_v1-1.md
+++ b/docs/v1-1/OpenDirect_OOH_1-5-1_v1-1.md
@@ -813,9 +813,9 @@ For GET calls that return a collection of resources, such as /accounts/{id}/orde
 | /organizations/organizations?$filter | organizations | [Organization](#_bookmark3) |
 | /advertiserbrands/advertiserbrands?$filter | advertiserbrands | AdvertiserBrand |
 | /accounts/accounts?$filter | accounts | Account |
-| /accounts/{id}/assignments/accounts/{id}/assignments?$filter | assignments | Assignment |
-| /accounts/{id}/orders/accounts/{id}/orders?$filter | orders | Order\_Campaign\_Assignment |
-| /accounts/{id}/orders/{id}/lines/accounts/{id}/orders/lines?$filter | lines | Lines\_Assignment |
+| /accounts/{id}/assignments?$filter | assignments | Assignment |
+| /accounts/{id}/orders?$filter | orders | Order\_Campaign\_Assignment |
+| /accounts/{id}/orders/{id}/lines?$filter | lines | Lines\_Assignment |
 | /products/products/search (POST) | products | Product\_Assignment |
 | /products/avails (POST) | avails | ProductAvails\_Assignment |
 | /oohbjects/dataSources/oohbjects/dataSources?filter | dataSources | Data Sources |


### PR DESCRIPTION
Based on the URI table in section 7.1 I think these examples are probably wrong, please feel free to ignore and close this pull request if that's not the case.

I'm not sure about the example on line 821 either (`/oohbjects/dataSources/oohbjects/dataSources?filter`) but I'm not sure what that should be replaced with so have left it untouched.